### PR TITLE
gnmi-tools - fix/workaround for failure in demo pytest tests 

### DIFF
--- a/tests/client_server_test_base.py
+++ b/tests/client_server_test_base.py
@@ -156,6 +156,7 @@ class GrpcBase(object):
                         read_count -= 1
                         if read_count == 0:
                             log.info("read count reached")
+                            responses.cancel()
                             break
             assert read_count == -1 or read_count == 0
 


### PR DESCRIPTION
(change_db not shared between handlers)