### PR TITLE
better resource de-allocation for the API adapter

### DIFF
--- a/src/confd_gnmi_adapter.py
+++ b/src/confd_gnmi_adapter.py
@@ -82,7 +82,7 @@ class GnmiServerAdapter(ABC):
             SAMPLE = 0
             SEND_CHANGES = 1
             FINISH = 10
-            ASYNC_FINISH = 15            
+            ASYNC_FINISH = 15
 
         def __init__(self, adapter, subscription_list):
             self.adapter = adapter

--- a/src/confd_gnmi_api_adapter.py
+++ b/src/confd_gnmi_api_adapter.py
@@ -346,7 +346,7 @@ class GnmiConfDApiServerAdapter(GnmiServerAdapter):
                         self.socket_loop(sub_sock)
                 except Exception as e:
                     log.exception(e)
-                    self.stop()
+                    self.async_stop()
             log.debug("<==")
 
         def start_monitoring(self):


### PR DESCRIPTION
In case the client closes connection while the adapter handles changes notifications, it may happen that the server thread fails to stop the notification thread before it is terminated, even though the "done" callback is invoked.  Now the notification thread is stopped in that callback.