### PR TITLE
update generated for empty non-presence containers

### DIFF
--- a/src/confd_gnmi_api_adapter.py
+++ b/src/confd_gnmi_api_adapter.py
@@ -599,10 +599,13 @@ class GnmiConfDApiServerAdapter(GnmiServerAdapter):
                 log.debug("save_result=%s", save_result)
                 assert save_result == 0
                 gnmi_path = self.make_gnmi_keypath(keypath, csnode)
-                # the format of saved_data is {"node": {data}}
-                # we need only the data part
-                assert len(saved_data) == 1
-                [data] = saved_data.values()
+                # the format of saved_data is {"node": {data}}, can be
+                # {} if the container is empty; we need only the data
+                # part
+                if not saved_data:
+                    data = {}
+                else:
+                    [data] = saved_data.values()
                 gnmi_value = gnmi_pb2.TypedValue(json_ietf_val=json.dumps(data).encode())
                 updates.append(gnmi_pb2.Update(path=gnmi_path, val=gnmi_value))
 


### PR DESCRIPTION
The adapter fails when the request targets a non-presence container that exists but its children do not; ConfD would generate an empty JSON document that is not processed correctly - this is fixed. The question is whether an empty update or no update at all should be returned in such case. The implementation goes with the former with the following reasoning:
- we return no update if the path simply does not exist, so it makes sense to behave differently here;
- the specification seems to require that in [GetResponse Behavior Table](https://openconfig.net/docs/gnmi/gnmi-specification/#334-getresponse-behavior-table).