### PR TITLE
double subscriptions for both config and oper changes

### DIFF
--- a/src/confd_gnmi_api_adapter.py
+++ b/src/confd_gnmi_api_adapter.py
@@ -296,10 +296,11 @@ class GnmiConfDApiServerAdapter(GnmiServerAdapter):
                 is_cdb = flags & _tm.CS_NODE_IS_CDB
                 if is_cdb:
                     subscribed = True
-                    cdb_type = cdb.SUB_RUNNING if flags & _tm.CS_NODE_IS_WRITE \
-                        else cdb.SUB_OPERATIONAL
-                    spoint = cdb.subscribe2(sub_sock, cdb_type, 0, prio, 0, path_str)
+                    spoint = cdb.subscribe2(sub_sock, cdb.SUB_OPERATIONAL, 0, prio, 0, path_str)
                     self.subpoint_paths[spoint] = subpoint_path
+                    if flags & _tm.CS_NODE_IS_WRITE:
+                        spoint = cdb.subscribe2(sub_sock, cdb.SUB_RUNNING, 0, prio, 0, path_str)
+                        self.subpoint_paths[spoint] = subpoint_path
                 else:
                     has_non_cdb = True
             if subscribed:

--- a/tests/test_client_server_confd.py
+++ b/tests/test_client_server_confd.py
@@ -134,6 +134,22 @@ class TestGrpcConfD(GrpcBase):
 
     @pytest.mark.long
     @pytest.mark.confd
+    def test_subscribe_stream_with_state(self, request):
+        log.info("testing subscribe_stream with state under config")
+        changes_list = [
+            ("interface[name=gig0]/state/loopback-mode", "NONE"),
+            ("interface[name=gig2]/state/loopback-mode", "NONE"),
+            "send",
+            ("interface[name=gig0]/state/loopback-mode", "FACILITY"),
+            ("interface[name=gig2]/state/loopback-mode", "FACILITY"),
+            "send"]
+        prefix_str = '{prefix}interfaces'
+        paths = [make_gnmi_path("/interface")]
+        self._test_subscribe(prefix_str, self.NS_OC_INTERFACES,
+                             paths, changes_list)
+
+    @pytest.mark.long
+    @pytest.mark.confd
     def test_subscribe_stream_on_change_api_state(self, request):
         log.info("testing test_subscribe_stream_on_change_api_state")
         GnmiConfDApiServerAdapter.monitor_external_changes = True


### PR DESCRIPTION
If the subscription request is for a config node, only config subscription would be created, so if there are operational nodes below the subscription point, no changes on those nodes would be caught.  Second, oper subscription has been added to fix that.