### PR TITLE
fixture implementation must be an iterator

### DIFF
--- a/tests/client_server_test_base.py
+++ b/tests/client_server_test_base.py
@@ -78,7 +78,7 @@ class GrpcBase:
 
     @pytest.fixture
     def reset_cfg(self):
-        self._do_reset_cfg()
+        yield from self._do_reset_cfg()
 
 
 class AdapterTests(GrpcBase):

--- a/tests/test_client_server_confd.py
+++ b/tests/test_client_server_confd.py
@@ -253,7 +253,7 @@ class TestGrpcConfD(AdapterTests):
         self.client.set_request(None, update=[update])
 
     def _do_reset_cfg(self):
-        reset_confd_config()
+        return reset_confd_config()
 
 
 class TestGrpcConfDSet(GrpcBase):
@@ -321,4 +321,4 @@ class TestGrpcConfDSet(GrpcBase):
         self.assert_instance(list_ix=2, value='efgh')
 
     def _do_reset_cfg(self):
-        reset_confd_config()
+        return reset_confd_config()

--- a/tests/test_client_server_demo.py
+++ b/tests/test_client_server_demo.py
@@ -15,4 +15,4 @@ class TestGrpcDemo(AdapterTests):
         self.adapter_type = AdapterType.DEMO
 
     def _do_reset_cfg(self):
-        pass
+        yield


### PR DESCRIPTION
The reset_cfg fixture must be an iterator and its implementations need to reflect that.